### PR TITLE
`CLPoolSwap` refactoring + fixing remaining tests

### DIFF
--- a/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
+++ b/src/EventHandlers/CLPool/CLPoolSwapLogic.ts
@@ -1,0 +1,312 @@
+import type {
+  CLPool_Swap_event,
+  LiquidityPoolAggregator,
+  Token,
+  handlerContext,
+} from "generated";
+import { normalizeTokenAmountTo1e18 } from "../../Helpers";
+import { abs, multiplyBase1e18 } from "../../Maths";
+import { refreshTokenPrice } from "../../PriceOracle";
+import { updateCLPoolLiquidity } from "./updateCLPoolLiquidity";
+
+export interface CLPoolSwapResult {
+  CLPoolSwapEntity: {
+    id: string;
+    sender: string;
+    recipient: string;
+    amount0: bigint;
+    amount1: bigint;
+    sqrtPriceX96: bigint;
+    liquidity: bigint;
+    tick: bigint;
+    sourceAddress: string;
+    timestamp: Date;
+    blockNumber: number;
+    logIndex: number;
+    chainId: number;
+    transactionHash: string;
+  };
+  liquidityPoolDiff?: Partial<LiquidityPoolAggregator>;
+  liquidityPoolAggregator?: LiquidityPoolAggregator;
+  error?: string;
+}
+
+type SwapEntityData = {
+  liquidityPoolAggregator: LiquidityPoolAggregator;
+  token0Instance: Token | undefined;
+  token1Instance: Token | undefined;
+  tokenUpdateData: {
+    netAmount0: bigint;
+    netAmount1: bigint;
+    netVolumeToken0USD: bigint;
+    netVolumeToken1USD: bigint;
+    volumeInUSD: bigint;
+    volumeInUSDWhitelisted: bigint;
+  };
+  liquidityPoolAggregatorDiff: Partial<LiquidityPoolAggregator>;
+};
+
+export type CLPoolSwapLoaderReturn =
+  | {
+      _type: "success";
+      liquidityPoolAggregator: LiquidityPoolAggregator;
+      token0Instance: Token | undefined;
+      token1Instance: Token | undefined;
+    }
+  | {
+      _type: "TokenNotFoundError";
+      message: string;
+    }
+  | {
+      _type: "LiquidityPoolAggregatorNotFoundError";
+      message: string;
+    };
+
+const updateToken0SwapData = async (
+  data: SwapEntityData,
+  event: CLPool_Swap_event,
+  context: handlerContext,
+) => {
+  let {
+    liquidityPoolAggregator,
+    token0Instance,
+    tokenUpdateData,
+    liquidityPoolAggregatorDiff,
+  } = data;
+  liquidityPoolAggregatorDiff = {
+    ...liquidityPoolAggregatorDiff,
+    totalVolume0:
+      liquidityPoolAggregator.totalVolume0 + tokenUpdateData.netAmount0,
+  };
+  if (!token0Instance) return { ...data, liquidityPoolAggregatorDiff };
+
+  try {
+    token0Instance = await refreshTokenPrice(
+      token0Instance,
+      event.block.number,
+      event.block.timestamp,
+      event.chainId,
+      context,
+      1000000n,
+    );
+  } catch (error) {
+    context.log.error(
+      `Error refreshing token price for ${token0Instance?.address} on chain ${event.chainId}: ${error}`,
+    );
+  }
+  const normalizedAmount0 = normalizeTokenAmountTo1e18(
+    abs(event.params.amount0),
+    Number(token0Instance.decimals),
+  );
+
+  tokenUpdateData.netVolumeToken0USD = multiplyBase1e18(
+    normalizedAmount0,
+    token0Instance.pricePerUSDNew,
+  );
+  tokenUpdateData.volumeInUSD = tokenUpdateData.netVolumeToken0USD;
+
+  liquidityPoolAggregatorDiff = {
+    ...liquidityPoolAggregatorDiff,
+    token0Price:
+      token0Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token0Price,
+    token0IsWhitelisted: token0Instance?.isWhitelisted ?? false,
+  };
+
+  return {
+    ...data,
+    liquidityPoolAggregatorDiff,
+    token0Instance,
+    tokenUpdateData,
+  };
+};
+
+const updateToken1SwapData = async (
+  data: SwapEntityData,
+  event: CLPool_Swap_event,
+  context: handlerContext,
+) => {
+  let {
+    liquidityPoolAggregator,
+    token1Instance,
+    tokenUpdateData,
+    liquidityPoolAggregatorDiff,
+  } = data;
+  liquidityPoolAggregatorDiff = {
+    ...liquidityPoolAggregatorDiff,
+    totalVolume1:
+      liquidityPoolAggregator.totalVolume1 + tokenUpdateData.netAmount1,
+  };
+  if (!token1Instance) return { ...data, liquidityPoolAggregatorDiff };
+
+  try {
+    token1Instance = await refreshTokenPrice(
+      token1Instance,
+      event.block.number,
+      event.block.timestamp,
+      event.chainId,
+      context,
+      1000000n,
+    );
+  } catch (error) {
+    context.log.error(
+      `Error refreshing token price for ${token1Instance?.address} on chain ${event.chainId}: ${error}`,
+    );
+  }
+  const normalizedAmount1 = normalizeTokenAmountTo1e18(
+    abs(event.params.amount1),
+    Number(token1Instance.decimals),
+  );
+  tokenUpdateData.netVolumeToken1USD = multiplyBase1e18(
+    normalizedAmount1,
+    token1Instance.pricePerUSDNew,
+  );
+
+  // Use volume from token 0 if it's priced, otherwise use token 1
+  tokenUpdateData.volumeInUSD =
+    tokenUpdateData.netVolumeToken0USD !== 0n
+      ? tokenUpdateData.netVolumeToken0USD
+      : tokenUpdateData.netVolumeToken1USD;
+
+  liquidityPoolAggregatorDiff = {
+    ...liquidityPoolAggregatorDiff,
+    totalVolume1:
+      liquidityPoolAggregator.totalVolume1 + tokenUpdateData.netAmount1,
+    token1Price:
+      token1Instance?.pricePerUSDNew ?? liquidityPoolAggregator.token1Price,
+    token1IsWhitelisted: token1Instance?.isWhitelisted ?? false,
+  };
+
+  return {
+    ...data,
+    liquidityPoolAggregatorDiff,
+    tokenUpdateData,
+    token1Instance,
+  };
+};
+
+const updateLiquidityPoolAggregatorDiffSwap = (
+  data: SwapEntityData,
+  reserveResult: {
+    addTotalLiquidityUSD: bigint;
+    reserve0: bigint;
+    reserve1: bigint;
+  },
+) => {
+  data.liquidityPoolAggregatorDiff = {
+    ...data.liquidityPoolAggregatorDiff,
+    numberOfSwaps: data.liquidityPoolAggregator.numberOfSwaps + 1n,
+    reserve0: data.liquidityPoolAggregator.reserve0 + reserveResult.reserve0,
+    reserve1: data.liquidityPoolAggregator.reserve1 + reserveResult.reserve1,
+    totalVolumeUSD:
+      data.liquidityPoolAggregator.totalVolumeUSD +
+      data.tokenUpdateData.volumeInUSD,
+    totalVolumeUSDWhitelisted:
+      data.liquidityPoolAggregator.totalVolumeUSDWhitelisted +
+      data.tokenUpdateData.volumeInUSDWhitelisted,
+    totalLiquidityUSD: reserveResult.addTotalLiquidityUSD,
+  };
+  return data;
+};
+
+export async function processCLPoolSwap(
+  event: CLPool_Swap_event,
+  loaderReturn: CLPoolSwapLoaderReturn,
+  context: handlerContext,
+): Promise<CLPoolSwapResult> {
+  // Create the entity
+  const CLPoolSwapEntity = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    sender: event.params.sender,
+    recipient: event.params.recipient,
+    amount0: event.params.amount0,
+    amount1: event.params.amount1,
+    sqrtPriceX96: event.params.sqrtPriceX96,
+    liquidity: event.params.liquidity,
+    tick: event.params.tick,
+    sourceAddress: event.srcAddress,
+    timestamp: new Date(event.block.timestamp * 1000),
+    blockNumber: event.block.number,
+    logIndex: event.logIndex,
+    chainId: event.chainId,
+    transactionHash: event.transaction.hash,
+  };
+
+  // Handle different loader return types
+  switch (loaderReturn._type) {
+    case "success": {
+      // Delta that will be added to the liquidity pool aggregator
+      const tokenUpdateData = {
+        netAmount0: abs(event.params.amount0),
+        netAmount1: abs(event.params.amount1),
+        netVolumeToken0USD: 0n,
+        netVolumeToken1USD: 0n,
+        volumeInUSD: 0n,
+        volumeInUSDWhitelisted: 0n,
+      };
+
+      const liquidityPoolAggregatorDiff: Partial<LiquidityPoolAggregator> = {};
+
+      let successSwapEntityData: SwapEntityData = {
+        liquidityPoolAggregator: loaderReturn.liquidityPoolAggregator,
+        token0Instance: loaderReturn.token0Instance,
+        token1Instance: loaderReturn.token1Instance,
+        tokenUpdateData,
+        liquidityPoolAggregatorDiff,
+      };
+
+      successSwapEntityData = await updateToken0SwapData(
+        successSwapEntityData,
+        event,
+        context,
+      );
+      successSwapEntityData = await updateToken1SwapData(
+        successSwapEntityData,
+        event,
+        context,
+      );
+
+      // If both tokens are whitelisted, add the volume of token0 to the whitelisted volume
+      successSwapEntityData.tokenUpdateData.volumeInUSDWhitelisted +=
+        successSwapEntityData.token0Instance?.isWhitelisted &&
+        successSwapEntityData.token1Instance?.isWhitelisted
+          ? successSwapEntityData.tokenUpdateData.netVolumeToken0USD
+          : 0n;
+
+      const successReserveResult = updateCLPoolLiquidity(
+        successSwapEntityData.liquidityPoolAggregator,
+        event,
+        successSwapEntityData.token0Instance,
+        successSwapEntityData.token1Instance,
+      );
+
+      // Merge with previous liquidity pool aggregator values.
+      successSwapEntityData = updateLiquidityPoolAggregatorDiffSwap(
+        successSwapEntityData,
+        successReserveResult,
+      );
+
+      return {
+        CLPoolSwapEntity,
+        liquidityPoolDiff: successSwapEntityData.liquidityPoolAggregatorDiff,
+        liquidityPoolAggregator: successSwapEntityData.liquidityPoolAggregator,
+      };
+    }
+    case "TokenNotFoundError":
+      return {
+        CLPoolSwapEntity,
+        error: loaderReturn.message,
+      };
+    case "LiquidityPoolAggregatorNotFoundError":
+      return {
+        CLPoolSwapEntity,
+        error: loaderReturn.message,
+      };
+    default: {
+      // This should never happen due to TypeScript's exhaustive checking
+      return {
+        CLPoolSwapEntity,
+        error: "Unknown error type",
+      };
+    }
+  }
+}

--- a/src/EventHandlers/Pool.ts
+++ b/src/EventHandlers/Pool.ts
@@ -198,6 +198,7 @@ Pool.Swap.handlerWithLoader({
             event.block.timestamp,
             event.chainId,
             context,
+            1000000n,
           );
         } catch (error) {
           context.log.error(
@@ -222,6 +223,7 @@ Pool.Swap.handlerWithLoader({
             event.block.timestamp,
             event.chainId,
             context,
+            1000000n,
           );
         } catch (error) {
           context.log.error(

--- a/src/EventHandlers/VotingReward.ts
+++ b/src/EventHandlers/VotingReward.ts
@@ -70,6 +70,7 @@ VotingReward.NotifyReward.handlerWithLoader({
             event.params.reward,
             event.block.number,
             event.chainId,
+            1000000n,
           );
         } catch (error) {
           context.log.error(

--- a/test/EventHandlers/CLPool/CLPool.test.ts
+++ b/test/EventHandlers/CLPool/CLPool.test.ts
@@ -227,7 +227,7 @@ describe("CLPool Event Handlers", () => {
             timestamp: 1000000,
             hash: "0xblockhash",
           },
-          chainId: 1,
+          chainId: 10,
           logIndex: 0,
           srcAddress: poolId,
         },
@@ -330,7 +330,7 @@ describe("CLPool Event Handlers", () => {
             timestamp: 1000000,
             hash: "0xblockhash",
           },
-          chainId: 1,
+          chainId: 10,
           logIndex: 0,
           srcAddress: poolId,
         },
@@ -435,18 +435,15 @@ describe("CLPool Event Handlers", () => {
     const expectations = {
       amount0In: -10n * 10n ** 18n,
       amount1In: 10n * 10n ** 6n,
-      totalLiquidityUSD: 0n,
+      // Note because the swap is negative for token 0, we add it to the reserve
+      totalLiquidityUSD:
+        (BigInt(mockLiquidityPoolData.reserve0 + -10n * 10n ** 18n) *
+          mockToken0Data.pricePerUSDNew) /
+          10n ** mockToken0Data.decimals +
+        (BigInt(mockLiquidityPoolData.reserve1 + 10n * 10n ** 6n) *
+          mockToken1Data.pricePerUSDNew) /
+          10n ** mockToken1Data.decimals,
     };
-
-    // Note because the swap is negative for token 0, we add it to the reserve
-    // expectations.totalLiquidityUSD =
-    const te1: bigint =
-      (BigInt(mockLiquidityPoolData.reserve0 + expectations.amount0In) *
-        mockToken0Data.pricePerUSDNew) /
-        10n ** mockToken0Data.decimals +
-      (BigInt(mockLiquidityPoolData.reserve1 + expectations.amount1In) *
-        mockToken1Data.pricePerUSDNew) /
-        10n ** mockToken1Data.decimals;
 
     const mockEvent = CLPool.Swap.createMockEvent({
       sender: "0xsender",
@@ -462,7 +459,7 @@ describe("CLPool Event Handlers", () => {
           timestamp: 1000000,
           hash: "0xblockhash",
         },
-        chainId: 1,
+        chainId: 10,
         logIndex: 0,
         srcAddress: poolId,
       },
@@ -482,7 +479,7 @@ describe("CLPool Event Handlers", () => {
           event: mockEvent,
           mockDb: updatedDB,
         });
-        swapEntity = result.entities.CLPool_Swap.get("1_123456_0");
+        swapEntity = result.entities.CLPool_Swap.get("10_123456_0");
         const aggregatorCalls =
           updateLiquidityPoolAggregatorStub.firstCall.args;
         updatedLiquidityPool = aggregatorCalls[0];

--- a/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
+++ b/test/EventHandlers/CLPool/CLPoolSwapLogic.test.ts
@@ -1,0 +1,382 @@
+import { expect } from "chai";
+import type {
+  CLPool_Swap_event,
+  LiquidityPoolAggregator,
+  Token,
+  handlerContext,
+} from "generated";
+import sinon from "sinon";
+import { processCLPoolSwap } from "../../../src/EventHandlers/CLPool/CLPoolSwapLogic";
+import * as PriceOracle from "../../../src/PriceOracle";
+
+describe("CLPoolSwapLogic", () => {
+  // Shared mock event for all tests
+  const mockEvent: CLPool_Swap_event = {
+    params: {
+      sender: "0x1111111111111111111111111111111111111111",
+      recipient: "0x2222222222222222222222222222222222222222",
+      amount0: 1000n,
+      amount1: -500n,
+      sqrtPriceX96: 79228162514264337593543950336n, // 1 << 96
+      liquidity: 10000n,
+      tick: 0n,
+    },
+    srcAddress: "0x3333333333333333333333333333333333333333",
+    transaction: {
+      hash: "0x4444444444444444444444444444444444444444444444444444444444444444",
+    },
+    block: {
+      timestamp: 1000000,
+      number: 123456,
+      hash: "0x5555555555555555555555555555555555555555555555555555555555555555",
+    },
+    chainId: 10,
+    logIndex: 1,
+  };
+
+  // Mock context
+  const mockLogError = sinon.stub();
+  const mockContext = {
+    log: {
+      error: mockLogError,
+    },
+  } as unknown as handlerContext;
+
+  // Mock liquidity pool aggregator
+  const mockLiquidityPoolAggregator: LiquidityPoolAggregator = {
+    id: "0x3333333333333333333333333333333333333333",
+    chainId: 10,
+    token0_id: "token0_id",
+    token1_id: "token1_id",
+    token0_address: "0x1111111111111111111111111111111111111111",
+    token1_address: "0x2222222222222222222222222222222222222222",
+    isStable: false,
+    reserve0: 1000n,
+    reserve1: 1000n,
+    totalLiquidityUSD: 2000n,
+    totalVolume0: 0n,
+    totalVolume1: 0n,
+    totalVolumeUSD: 1200n,
+    totalVolumeUSDWhitelisted: 1200n,
+    gaugeFees0CurrentEpoch: 0n,
+    gaugeFees1CurrentEpoch: 0n,
+    totalFees0: 0n,
+    totalFees1: 0n,
+    totalFeesUSD: 0n,
+    totalFeesUSDWhitelisted: 0n,
+    numberOfSwaps: 0n,
+    token0Price: 1000000000000000000n, // 1 USD in 1e18
+    token1Price: 5000000000000000000n, // 5 USD in 1e18
+    totalVotesDeposited: 0n,
+    totalVotesDepositedUSD: 0n,
+    totalEmissions: 0n,
+    totalEmissionsUSD: 0n,
+    totalBribesUSD: 0n,
+    gaugeIsAlive: true,
+    isCL: true,
+    lastUpdatedTimestamp: new Date(),
+    lastSnapshotTimestamp: new Date(),
+    token0IsWhitelisted: true,
+    token1IsWhitelisted: true,
+    name: "Test Pool",
+  };
+
+  // Mock token instances
+  const mockToken0: Token = {
+    id: "token0_id",
+    address: "0x1111111111111111111111111111111111111111",
+    symbol: "USDT",
+    name: "Tether USD",
+    decimals: 18n,
+    pricePerUSDNew: 1000000000000000000n, // 1 USD
+    chainId: 10,
+    isWhitelisted: true,
+    lastUpdatedTimestamp: new Date(),
+  };
+
+  const mockToken1: Token = {
+    id: "token1_id",
+    address: "0x2222222222222222222222222222222222222222",
+    symbol: "USDC",
+    name: "USD Coin",
+    decimals: 6n,
+    pricePerUSDNew: 1000000000000000000n, // 1 USD
+    chainId: 10,
+    isWhitelisted: true,
+    lastUpdatedTimestamp: new Date(),
+  };
+
+  let refreshTokenPriceStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    refreshTokenPriceStub = sinon
+      .stub(PriceOracle, "refreshTokenPrice")
+      .callsFake(async (token) => token); // Return the token as-is
+    mockLogError.reset();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("processCLPoolSwap", () => {
+    it("should create entity and calculate swap updates for successful swap", async () => {
+      // Mock loader return
+      const mockLoaderReturn = {
+        _type: "success" as const,
+        liquidityPoolAggregator: mockLiquidityPoolAggregator,
+        token0Instance: mockToken0,
+        token1Instance: mockToken1,
+      };
+
+      // Process the swap event
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      // Assertions
+      expect(result.CLPoolSwapEntity).to.deep.include({
+        id: "10_123456_1",
+        sender: "0x1111111111111111111111111111111111111111",
+        recipient: "0x2222222222222222222222222222222222222222",
+        amount0: 1000n,
+        amount1: -500n,
+        sqrtPriceX96: 79228162514264337593543950336n,
+        liquidity: 10000n,
+        tick: 0n,
+        sourceAddress: "0x3333333333333333333333333333333333333333",
+        blockNumber: 123456,
+        logIndex: 1,
+        chainId: 10,
+        transactionHash:
+          "0x4444444444444444444444444444444444444444444444444444444444444444",
+      });
+
+      expect(result.liquidityPoolDiff).to.exist;
+      expect(result.liquidityPoolAggregator).to.exist;
+      expect(result.error).to.be.undefined;
+
+      // Verify liquidity pool diff content - all fields that should be set
+      expect(result.liquidityPoolDiff).to.include({
+        // From updateToken0SwapData
+        totalVolume0: 1000n, // liquidityPoolAggregator.totalVolume0 + tokenUpdateData.netAmount0
+        token0Price: 1000000000000000000n, // from mockToken0.pricePerUSDNew
+        token0IsWhitelisted: true, // from mockToken0.isWhitelisted
+
+        // From updateToken1SwapData
+        totalVolume1: 500n, // liquidityPoolAggregator.totalVolume1 + tokenUpdateData.netAmount1
+        token1Price: 1000000000000000000n, // from mockToken1.pricePerUSDNew
+        token1IsWhitelisted: true, // from mockToken1.isWhitelisted
+
+        // From updateLiquidityPoolAggregatorDiffSwap
+        numberOfSwaps: 1n, // liquidityPoolAggregator.numberOfSwaps + 1n
+        reserve0: 2000n, // 1000n + 1000n (existing + event.params.amount0)
+        reserve1: 500n, // 1000n + (-500n) (existing + event.params.amount1)
+        totalVolumeUSD: 2200n, // liquidityPoolAggregator.totalVolumeUSD + tokenUpdateData.volumeInUSD
+        totalVolumeUSDWhitelisted: 2200n, // liquidityPoolAggregator.totalVolumeUSDWhitelisted + tokenUpdateData.volumeInUSDWhitelisted
+        totalLiquidityUSD: 2500000000002000n, // from reserveResult.addTotalLiquidityUSD
+      });
+
+      // Verify that refreshTokenPrice was called for both tokens
+      expect(refreshTokenPriceStub.calledTwice).to.be.true;
+      expect(
+        refreshTokenPriceStub.firstCall.calledWith(
+          mockToken0,
+          123456,
+          1000000,
+          10,
+          mockContext,
+          1000000n,
+        ),
+      ).to.be.true;
+      expect(
+        refreshTokenPriceStub.secondCall.calledWith(
+          mockToken1,
+          123456,
+          1000000,
+          10,
+          mockContext,
+          1000000n,
+        ),
+      ).to.be.true;
+    });
+
+    it("should handle TokenNotFoundError", async () => {
+      const mockLoaderReturn = {
+        _type: "TokenNotFoundError" as const,
+        message: "Token not found",
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.error).to.equal("Token not found");
+      expect(result.liquidityPoolDiff).to.be.undefined;
+      expect(result.liquidityPoolAggregator).to.be.undefined;
+    });
+
+    it("should handle LiquidityPoolAggregatorNotFoundError", async () => {
+      const mockLoaderReturn = {
+        _type: "LiquidityPoolAggregatorNotFoundError" as const,
+        message: "Liquidity pool aggregator not found",
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.error).to.equal("Liquidity pool aggregator not found");
+      expect(result.liquidityPoolDiff).to.be.undefined;
+      expect(result.liquidityPoolAggregator).to.be.undefined;
+    });
+
+    it("should handle unknown error type", async () => {
+      const mockLoaderReturn = {
+        _type: "UnknownError" as never,
+        message: "Some unknown error",
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.error).to.equal("Unknown error type");
+      expect(result.liquidityPoolDiff).to.be.undefined;
+      expect(result.liquidityPoolAggregator).to.be.undefined;
+    });
+
+    it("should handle refreshTokenPrice errors gracefully", async () => {
+      // Mock refreshTokenPrice to throw an error for token0
+      refreshTokenPriceStub
+        .onFirstCall()
+        .rejects(new Error("Price refresh failed"))
+        .onSecondCall()
+        .callsFake(async (token) => token);
+
+      const mockLoaderReturn = {
+        _type: "success" as const,
+        liquidityPoolAggregator: mockLiquidityPoolAggregator,
+        token0Instance: mockToken0,
+        token1Instance: mockToken1,
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      // Should still create the entity and continue processing
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.liquidityPoolDiff).to.exist;
+      expect(result.liquidityPoolAggregator).to.exist;
+      expect(result.error).to.be.undefined;
+
+      // Verify error was logged
+      expect(mockLogError.calledOnce).to.be.true;
+      expect(mockLogError.firstCall.args[0]).to.include(
+        "Error refreshing token price",
+      );
+    });
+
+    it("should handle missing token0Instance", async () => {
+      const mockLoaderReturn = {
+        _type: "success" as const,
+        liquidityPoolAggregator: mockLiquidityPoolAggregator,
+        token0Instance: undefined,
+        token1Instance: mockToken1,
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.liquidityPoolDiff).to.exist;
+      expect(result.liquidityPoolAggregator).to.exist;
+      expect(result.error).to.be.undefined;
+
+      // Should only call refreshTokenPrice for token1
+      expect(refreshTokenPriceStub.calledOnce).to.be.true;
+      expect(refreshTokenPriceStub.firstCall.calledWith(
+        mockToken1,
+        123456,
+        1000000,
+        10,
+        mockContext,
+        1000000n,
+      )).to.be.true;
+    });
+
+    it("should handle missing token1Instance", async () => {
+      const mockLoaderReturn = {
+        _type: "success" as const,
+        liquidityPoolAggregator: mockLiquidityPoolAggregator,
+        token0Instance: mockToken0,
+        token1Instance: undefined,
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.liquidityPoolDiff).to.exist;
+      expect(result.liquidityPoolAggregator).to.exist;
+      expect(result.error).to.be.undefined;
+
+      // Should only call refreshTokenPrice for token0
+      expect(refreshTokenPriceStub.calledOnce).to.be.true;
+      expect(refreshTokenPriceStub.firstCall.calledWith(
+        mockToken0,
+        123456,
+        1000000,
+        10,
+        mockContext,
+        1000000n,
+      )).to.be.true;
+    });
+
+    it("should not add to whitelisted volume when tokens are not whitelisted", async () => {
+      const mockLoaderReturn = {
+        _type: "success" as const,
+        liquidityPoolAggregator: mockLiquidityPoolAggregator,
+        token0Instance: { ...mockToken0, isWhitelisted: false },
+        token1Instance: { ...mockToken1, isWhitelisted: false },
+      };
+
+      const result = await processCLPoolSwap(
+        mockEvent,
+        mockLoaderReturn,
+        mockContext,
+      );
+
+      expect(result.CLPoolSwapEntity).to.exist;
+      expect(result.liquidityPoolDiff).to.exist;
+      expect(result.liquidityPoolAggregator).to.exist;
+      expect(result.error).to.be.undefined;
+
+      // When tokens are not whitelisted, whitelisted volume should remain the same (no new whitelisted volume added)
+      expect(result.liquidityPoolDiff?.totalVolumeUSDWhitelisted).to.equal(
+        1200n,
+      );
+      expect(result.liquidityPoolDiff?.totalVolumeUSD).to.equal(2200n); // But total volume should still be calculated
+    });
+  });
+});

--- a/test/PriceOracle.test.ts
+++ b/test/PriceOracle.test.ts
@@ -71,6 +71,7 @@ describe("PriceOracle", () => {
             callData.tokenAddress,
             callData.blockNumber,
             callData.chainId,
+            1000000n,
           );
           const diff = priceData.pricePerUSDNew - 10n ** 18n;
           expect(diff < expectedDiff).to.be.true;
@@ -119,6 +120,7 @@ describe("PriceOracle", () => {
           blockTimestamp,
           chainId,
           mockContext,
+          1000000n,
         );
       });
       it("should not update prices if the update interval hasn't passed", async () => {
@@ -143,6 +145,7 @@ describe("PriceOracle", () => {
           blockTimestamp,
           chainId,
           mockContext,
+          1000000n,
         );
         updatedToken = mockContext.Token.set.lastCall.args[0];
       });
@@ -212,6 +215,7 @@ describe("PriceOracle", () => {
               test.tokenAddress,
               test.blockNumber,
               test.chainId,
+              1000000n,
             );
             expect(price.pricePerUSDNew).to.equal(996633595813270431n); // Close to 10 ** 18
           });
@@ -255,6 +259,7 @@ describe("PriceOracle", () => {
               test.tokenAddress,
               test.blockNumber,
               test.chainId,
+              5000000n, // with 1 million the simulationContract reverts
             );
             expect(price.pricePerUSDNew).to.equal(2063950680307235736469n);
           });
@@ -303,6 +308,7 @@ describe("PriceOracle", () => {
               test.tokenAddress,
               blockNumber,
               chainId,
+              1000000n,
             );
             expect(price.pricePerUSDNew).to.equal(2294389397280012597629n);
           });
@@ -312,6 +318,7 @@ describe("PriceOracle", () => {
               test.tokenAddress,
               blockNumber,
               chainId,
+              5000000n, // with 1 million the simulationContract reverts
             );
             expect(price.pricePerUSDNew).to.equal(2067268302000000000000n);
           });


### PR DESCRIPTION
Implements:
- Refactored logic for `CLPoolSwap` event handler
- Fix of remaining tests. **All tests pass now** and only 2 are in "pending". The ones that are in pending are expected because they are within `xit` context, which simply skips the tests. Will analyse if it makes sense to not skipped it in future PRs.